### PR TITLE
build(android): fix release build for assembleAndroidTest

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ def reactNativeArchitectures() {
 
 android {
     ndkVersion rootProject.ext.ndkVersion
-
+    testBuildType "release"
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     namespace "com.reactnativecliquickstart"


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): fix detox release build for workflow `e2e-android.yml`

https://github.com/facebook/react-native/issues/36207#issuecomment-1435838521

## What is the current behavior?

Detox build does not generate `./android/release/app-release-androidTest.apk` when running:

```sh
yarn detox build --configuration android.emu.release
```

Build output:

```sh
$ tree android/app/build/outputs
android/app/build/outputs
├── apk
│   ├── androidTest
│   │   └── debug
│   │       ├── app-debug-androidTest.apk
│   │       └── output-metadata.json
│   ├── debug
│   │   ├── app-debug.apk
│   │   └── output-metadata.json
│   └── release
│       ├── app-release.apk
│       └── output-metadata.json
├── logs
│   ├── manifest-merger-debug-report.txt
│   └── manifest-merger-release-report.txt
└── sdk-dependencies
    └── release
        └── sdkDependencies.txt

9 directories, 9 files
```

## What is the new behavior?

Detox build generates `./android/release/app-release-androidTest.apk` when running:

```sh
yarn detox build --configuration android.emu.release
```

Build output:

```sh
$ tree android/app/build/outputs
android/app/build/outputs
├── apk
│   ├── androidTest
│   │   ├── debug
│   │   │   ├── app-debug-androidTest.apk
│   │   │   └── output-metadata.json
│   │   └── release
│   │       ├── app-release-androidTest.apk
│   │       └── output-metadata.json
│   ├── debug
│   │   ├── app-debug.apk
│   │   └── output-metadata.json
│   └── release
│       ├── app-release.apk
│       └── output-metadata.json
├── logs
│   ├── manifest-merger-debug-report.txt
│   └── manifest-merger-release-report.txt
└── sdk-dependencies
    └── release
        └── sdkDependencies.txt

10 directories, 11 files
```